### PR TITLE
Switch to Cloudflare Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ All scripts are designed to be minimal, focused, and non-blocking to maintain th
 
 I've optimized the site in several ways:
 
-1. **Image Processing**: Using Astro's `getImage` function to convert images to efficient formats and appropriate dimensions.
+1. **Image Processing**: Images are served through Cloudflare's image resizing service to deliver optimized formats and dimensions.
 
 2. **Lazy Loading**: Images load on demand using the `loading="lazy"` attribute, which prevents initial page load delays.
 
@@ -941,20 +941,16 @@ The photo gallery displays use a custom masonry layout implementation:
 
 2. **Image Optimization**: The `Masonry.astro` component uses Astro's built-in image optimization:
    ```astro
-   const imageAssets = await Promise.all(
-     images.map(async (image) => {
-       if (image) {
-         return await getImage({
-           src: image.src,
-           alt: image.alt,
-           width: 3840,
-           height: 2160,
-           format: "avif",
-           loading: "lazy",
-         });
-       }
-     })
-   );
+  const imageAssets = images.map((image) =>
+    image
+      ? cfImage(image.src, image.alt, {
+          width: 3840,
+          height: 2160,
+          format: "avif",
+          loading: "lazy",
+        })
+      : null
+  );
    ```
 
 3. **Responsive Breakpoints**: The masonry layout adapts to screen sizes with custom media queries:

--- a/src/Architecture-README.md
+++ b/src/Architecture-README.md
@@ -87,8 +87,7 @@ The Masonry layout is a key visual feature of the site, implemented with CSS Gri
 graph TD
     A["Masonry.astro"] --> B["MasonryLayout.css"]
     A --> C["lightbox.js"]
-    A --> D["astro:assets"]
-    D --> E["getImage optimization"]
+    A --> D["Cloudflare Images"]
     
     classDef component fill:#f5d6c3,stroke:#333,stroke-width:1px
     classDef style fill:#c3e8f5,stroke:#333,stroke-width:1px
@@ -139,7 +138,7 @@ graph TD
 ### Image Processing Pipeline
 
 1. **Image Collection**: Images are specified in MDX frontmatter
-2. **Optimization**: The `getImage` function from `astro:assets` processes each image:
+2. **Optimization**: Cloudflare's image resizing service delivers transformed images:
    - Converts to AVIF format for better compression
    - Sets loading="lazy" for performance
    - Handles proper width/height attributes for CLS prevention

--- a/src/Performance-README.md
+++ b/src/Performance-README.md
@@ -39,20 +39,16 @@ Images are processed through Astro's built-in image optimization:
 
 ```javascript
 // Masonry.astro
-const imageAssets = await Promise.all(
-  images.map(async (image) => {
-    if (image) {
-      return await getImage({
-        src: image.src,
+const imageAssets = images.map((image) =>
+  image
+    ? cfImage(image.src, image.alt, {
         width: 3840,  // Maximum quality size
         height: 2160, // Maintains aspect ratio
         format: "avif", // Optimal compression format
         loading: "lazy", // Defer loading of off-screen images
         decoding: "async", // Allow browser to decode image asynchronously
-      });
-    }
-    return null;
-  }),
+      })
+    : null,
 );
 ```
 

--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -1,5 +1,5 @@
 ---
-import { Image } from "astro:assets";
+import { cfImage } from "../utils/cloudflare-image";
 
 const { title, url, image, alt, description, pubDate, positionx, positiony } =
   Astro.props;
@@ -17,14 +17,17 @@ const publishedDate = new Date(pubDate).toLocaleDateString("en-US", {
     image && (
       <div class="flex sm:w-1/3 md:h-[480px] h-[360px] fade-image rounded-lg">
         <a href={url} aria-label={`View full post: ${title}`}>
-          <Image
-            src={image}
+          <img
+            src={cfImage(image, alt, {
+              width: 640,
+              height: 480,
+              decoding: "async",
+              format: "avif",
+              quality: 65,
+            }).src}
             alt={alt}
-            width={640}
-            height={480}
-            decoding="async"
-            format="avif"
-            quality={65}
+            width="640"
+            height="480"
             class="h-full object-cover object-center post-image"
             style={`--position-x: ${positionx}; --position-y: ${positiony}; height: 100%`}
           />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,17 +2,19 @@
 import Hamburger from "./Hamburger.tsx";
 import Navigation from "./Navigation.astro";
 import ThemeToggle from "./ThemeToggle.astro";
-import { getImage } from "astro:assets";
+import { cfImage } from "../utils/cloudflare-image";
 const { is404Page = false } = Astro.props;
 
-const favicon_avif = await getImage({
-  src: "https://cdn.erfianugrah.com/ea_favicon.png",
-  alt: "favicon",
-  width: "640",
-  height: "480",
-  decoding: "async",
-  format: "avif",
-});
+const favicon_avif = cfImage(
+  "https://cdn.erfianugrah.com/ea_favicon.png",
+  "favicon",
+  {
+    width: 640,
+    height: 480,
+    decoding: "async",
+    format: "avif",
+  }
+);
 ---
 
 <header class="mb-[20px] mt-[-10px]">

--- a/src/components/Masonry.astro
+++ b/src/components/Masonry.astro
@@ -1,22 +1,17 @@
 ---
 import "../styles/MasonryLayout.css";
-import { getImage } from "astro:assets";
+import { cfImage } from "../utils/cloudflare-image";
 const { images } = Astro.props;
-const imageAssets = await Promise.all(
-  images.map(async (image) => {
-    if (image) {
-      return await getImage({
-        src: image.src,
-        alt: image.alt,
+const imageAssets = images.map((image) =>
+  image
+    ? cfImage(image.src, image.alt, {
         width: 3840,
         height: 2160,
         decoding: "async",
         format: "avif",
         loading: "lazy",
-      });
-    }
-    return null;
-  }),
+      })
+    : null,
 );
 ---
 

--- a/src/components/NextPost.astro
+++ b/src/components/NextPost.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from "astro:content";
-import { getImage } from "astro:assets";
+import { cfImage } from "../utils/cloudflare-image";
 import Prose from "./Prose.astro";
 
 export interface Props {
@@ -14,11 +14,8 @@ const allPosts = await getCollection(collection);
 const otherPosts = allPosts.filter((post) => post.id !== currentId);
 const shouldRender = otherPosts.length > 0;
 
-async function optimizeImage(src, alt) {
-  return await getImage({
-    src,
-    alt,
-    // layout: "responsive",
+function optimizeImage(src, alt) {
+  return cfImage(src, alt, {
     width: 640,
     height: 360,
     format: "avif",
@@ -27,10 +24,9 @@ async function optimizeImage(src, alt) {
   });
 }
 
-const postsData = await Promise.all(
-  otherPosts.map(async (post) => {
+const postsData = otherPosts.map((post) => {
     const imageData = post.data.image
-      ? await optimizeImage(
+      ? optimizeImage(
           post.data.image.src,
           post.data.image.alt || post.data.title,
         )
@@ -42,10 +38,9 @@ const postsData = await Promise.all(
       image: imageData ? imageData.src : null,
       alt: post.data.image?.alt || post.data.title,
     };
-  }),
-);
+  });
 
-const favicon = await optimizeImage(
+const favicon = optimizeImage(
   "https://cdn.erfianugrah.com/ea_favicon.png",
   "favicon",
 );

--- a/src/layouts/AuthorLayout.astro
+++ b/src/layouts/AuthorLayout.astro
@@ -2,7 +2,7 @@
 import BaseLayout from "./BaseLayout.astro";
 import "../styles/glightbox.css";
 import Prose from "../components/Prose.astro";
-import { getImage, Image } from "astro:assets";
+import { cfImage } from "../utils/cloudflare-image";
 const { frontmatter } = Astro.props;
 const updatedDate = frontmatter?.updatedDate
   .toDateString()
@@ -25,9 +25,7 @@ const alt = frontmatter.image?.alt;
 let baseUrl = new URL(Astro.request.url).origin;
 
 const metaImage = image
-  ? await getImage({
-      src: image,
-      alt: alt,
+  ? cfImage(image, alt, {
       width: 1280,
       height: 720,
       decoding: "async",
@@ -51,13 +49,17 @@ const metaImage = image
       image ? (
         <div>
           <div class="md:h-[480px] h-[360px]">
-            <Image
-              src={image}
+            <img
+              src={cfImage(image, alt, {
+                width: 1280,
+                height: 720,
+                decoding: "async",
+                format: "avif",
+                loading: "lazy",
+              }).src}
               alt={alt}
-              inferSize={true}
-              decoding="async"
-              format="avif"
-              loading="lazy"
+              width="1280"
+              height="720"
               style={`height: 100%`}
               data-pagefind-meta="image[src]"
             />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,13 +3,11 @@ import { ClientRouter } from "astro:transitions";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import ScrollToTop from "../components/scroll-to-top";
-import { getImage } from "astro:assets";
 import { Font } from "astro:assets";
+import { cfImage } from "../utils/cloudflare-image";
 import "../styles/global.css";
 let baseUrl = new URL(Astro.request.url).origin;
-const metaImage = await getImage({
-  src: "https://cdn.erfianugrah.com/Tenhult_3.JPG",
-  alt: "Cover image for stoicopa website",
+const metaImage = cfImage("https://cdn.erfianugrah.com/Tenhult_3.JPG", "Cover image for stoicopa website", {
   height: 720,
   width: 1280,
   decoding: "async",
@@ -17,9 +15,7 @@ const metaImage = await getImage({
   loading: "lazy",
 });
 
-const favicon_webp = await getImage({
-  src: "https://cdn.erfianugrah.com/ea_favicon.png",
-  alt: "stoicopa favicon",
+const favicon_webp = cfImage("https://cdn.erfianugrah.com/ea_favicon.png", "stoicopa favicon", {
   height: 400,
   width: 400,
   decoding: "async",
@@ -48,7 +44,7 @@ const personSchema = {
   "@type": "Person",
   name: "Erfi Anugrah",
   url: baseUrl,
-  image: `${baseUrl}${favicon_webp.src}`,
+  image: favicon_webp.src,
   sameAs: [
     "https://mastodon.social/@stoicopa",
     "https://github.com/erfianugrah",
@@ -116,7 +112,7 @@ const formattedUpdatedDate = updatedDate
     <meta property="og:site_name" content={site_name || "stoicopa"} />
     <meta
       property="og:image"
-      content={image || `${baseUrl}${metaImage?.src}`}
+      content={image || metaImage?.src}
     />
     <meta
       property="og:image:alt"
@@ -132,7 +128,7 @@ const formattedUpdatedDate = updatedDate
     <meta name="twitter:description" content={description || metaDescription} />
     <meta
       name="twitter:image"
-      content={image || `${baseUrl}${metaImage?.src}`}
+      content={image || metaImage?.src}
     />
     <meta
       name="twitter:image:alt"

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -3,7 +3,7 @@ import BaseLayout from "./BaseLayout.astro";
 import "../styles/glightbox.css";
 import "katex/dist/katex.min.css";
 import Prose from "../components/Prose.astro";
-import { getImage } from "astro:assets";
+import { cfImage } from "../utils/cloudflare-image";
 import HeroImage from "../components/HeroImage.tsx";
 import NextPost from "../components/NextPost.astro";
 
@@ -26,12 +26,9 @@ const image = frontmatter.image?.src;
 const alt = frontmatter.image?.alt;
 const positionx = frontmatter?.image?.positionx;
 const positiony = frontmatter?.image?.positiony;
-let baseUrl = new URL(Astro.request.url).origin;
 
 const backgroundImage = image
-  ? await getImage({
-      src: image,
-      alt: alt,
+  ? cfImage(image, alt, {
       width: 3840,
       height: 2160,
       format: "avif",
@@ -42,9 +39,7 @@ const backgroundImage = image
   : null;
 
 const mobileBackgroundImage = image
-  ? await getImage({
-      src: image,
-      alt: alt,
+  ? cfImage(image, alt, {
       width: 1920,
       height: 1080,
       format: "avif",
@@ -56,9 +51,7 @@ const mobileBackgroundImage = image
   : null;
 
 const metaImage = image
-  ? await getImage({
-      src: image,
-      alt: alt,
+  ? cfImage(image, alt, {
       width: 1280,
       height: 720,
       decoding: "async",
@@ -70,7 +63,7 @@ const metaImage = image
 
 <BaseLayout
   title={title}
-  image={image ? `${baseUrl}${metaImage?.src}` : ""}
+  image={image ? metaImage?.src : ""}
   alt={alt ? metaImage?.attributes.alt : ""}
   description={description}
   author={author}

--- a/src/layouts/TagLayout.astro
+++ b/src/layouts/TagLayout.astro
@@ -2,7 +2,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import GetRandomImage from "../components/getRandomImage.astro";
 import { getCollection } from "astro:content";
-import { getImage } from "astro:assets";
+import { cfImage } from "../utils/cloudflare-image";
 
 const { directory, title } = Astro.props;
 const allContent = await getCollection(directory);
@@ -15,38 +15,30 @@ for (const post of allContent) {
       imagesByTag[tag] = { large: [], medium: [], small: [], alt: [] };
     }
     if (post.data.image?.src) {
-      const [largeImage, mediumImage, smallImage] = await Promise.all([
-        getImage({
-          src: post.data.image.src,
-          alt: post.data.image.alt,
-          width: 1920,
-          height: 1080,
-          decoding: "async",
-          format: "avif",
-          quality: 65,
-        }),
-        getImage({
-          src: post.data.image.src,
-          alt: post.data.image.alt,
-          width: 1280,
-          height: 720,
-          decoding: "async",
-          format: "avif",
-          quality: 65,
-        }),
-        getImage({
-          src: post.data.image.src,
-          alt: post.data.image.alt,
-          width: 854,
-          height: 480,
-          decoding: "async",
-          format: "avif",
-          quality: 65,
-        }),
-      ]);
-      imagesByTag[tag].large.push(largeImage ? largeImage.src : null);
-      imagesByTag[tag].medium.push(mediumImage ? mediumImage.src : null);
-      imagesByTag[tag].small.push(smallImage ? smallImage.src : null);
+      const largeImage = cfImage(post.data.image.src, post.data.image.alt, {
+        width: 1920,
+        height: 1080,
+        decoding: "async",
+        format: "avif",
+        quality: 65,
+      });
+      const mediumImage = cfImage(post.data.image.src, post.data.image.alt, {
+        width: 1280,
+        height: 720,
+        decoding: "async",
+        format: "avif",
+        quality: 65,
+      });
+      const smallImage = cfImage(post.data.image.src, post.data.image.alt, {
+        width: 854,
+        height: 480,
+        decoding: "async",
+        format: "avif",
+        quality: 65,
+      });
+      imagesByTag[tag].large.push(largeImage.src);
+      imagesByTag[tag].medium.push(mediumImage.src);
+      imagesByTag[tag].small.push(smallImage.src);
       imagesByTag[tag].alt.push(post.data.image.alt);
     }
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import Homepage from "../components/Homepage.astro";
 const { pageTitle } = Astro.props;
 import { getCollection } from "astro:content";
-import { getImage } from "astro:assets";
+import { cfImage } from "../utils/cloudflare-image";
 
 const collections = ["long_form", "short_form", "muses", "zeitweilig"];
 let allImages = { large: [], medium: [], small: [] };
@@ -15,37 +15,28 @@ for (let collection of collections) {
     (post) => post.data.image?.src && post.data.image?.alt,
   );
 
-  const imagePromises = postsWithImages.map(async (post) => {
-    const [largeImage, mediumImage, smallImage] = await Promise.all([
-      getImage({
-        src: post.data.image.src,
-        alt: post.data.image.alt,
-        width: 1920,
-        height: 1080,
-        decoding: "async",
-        format: "avif",
-        quality: 65,
-      }),
-      getImage({
-        src: post.data.image.src,
-        alt: post.data.image.alt,
-        width: 1280,
-        height: 720,
-        decoding: "async",
-        format: "avif",
-        quality: 65,
-      }),
-      getImage({
-        src: post.data.image.src,
-        alt: post.data.image.alt,
-        width: 854,
-        height: 480,
-        decoding: "async",
-        format: "avif",
-        quality: 65,
-      }),
-    ]);
-
+  const results = postsWithImages.map((post) => {
+    const largeImage = cfImage(post.data.image.src, post.data.image.alt, {
+      width: 1920,
+      height: 1080,
+      decoding: "async",
+      format: "avif",
+      quality: 65,
+    });
+    const mediumImage = cfImage(post.data.image.src, post.data.image.alt, {
+      width: 1280,
+      height: 720,
+      decoding: "async",
+      format: "avif",
+      quality: 65,
+    });
+    const smallImage = cfImage(post.data.image.src, post.data.image.alt, {
+      width: 854,
+      height: 480,
+      decoding: "async",
+      format: "avif",
+      quality: 65,
+    });
     return {
       large: largeImage.src,
       medium: mediumImage.src,
@@ -54,8 +45,6 @@ for (let collection of collections) {
       url: `/${collection}/${post.id}`,
     };
   });
-
-  const results = await Promise.all(imagePromises);
 
   results.forEach((result) => {
     allImages.large.push(result.large);

--- a/src/utils/cloudflare-image.ts
+++ b/src/utils/cloudflare-image.ts
@@ -1,0 +1,32 @@
+export interface CFImageOptions {
+  width?: number;
+  height?: number;
+  format?: string;
+  quality?: number | string;
+  loading?: string;
+  decoding?: string;
+  fetchpriority?: string;
+}
+
+export function cfImage(src: string, alt: string, opts: CFImageOptions = {}) {
+  const url = new URL(src);
+  const path = url.pathname.startsWith('/') ? url.pathname.slice(1) : url.pathname;
+  const params: string[] = [];
+  if (opts.width) params.push(`width=${opts.width}`);
+  if (opts.height) params.push(`height=${opts.height}`);
+  if (opts.format) params.push(`format=${opts.format}`);
+  if (opts.quality) params.push(`quality=${opts.quality}`);
+  const options = params.join(',');
+  const cfUrl = `${url.origin}/cdn-cgi/image/${options}/${path}`;
+  return {
+    src: cfUrl,
+    attributes: {
+      alt,
+      width: opts.width,
+      height: opts.height,
+      loading: opts.loading,
+      decoding: opts.decoding,
+      fetchpriority: opts.fetchpriority,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add `cfImage` helper for Cloudflare Image Resizing
- update components and layouts to use Cloudflare URLs
- replace `<Image>` usage with `<img>`
- document Cloudflare image use in README and docs

## Testing
- `bun run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766c1c97688327a1c8fed16c454f77